### PR TITLE
fix: update swagger version

### DIFF
--- a/src/generate-tsed-swagger.ts
+++ b/src/generate-tsed-swagger.ts
@@ -33,7 +33,8 @@ function loadControllers(patterns: Array<string>): any[] {
     },
     swagger: [
         {
-            path: "/api-docs"
+            path: "/api-docs",
+            specVersion: "3.0.1"
         }
     ]
 })


### PR DESCRIPTION
# Error

Resource handler returned message: "Invalid model specified: Validation Result: warnings : [], errors : [Invalid model schema specified. Unsupported keyword(s): ["x-nullable"], Invalid model schema specified. Unsupported keyword(s): ["x-nullable"], Invalid model schema specified. Unsupported keyword(s): ["x-nullable"], Invalid model schema specified. Unsupported keyword(s): ["x-nullable"], Invalid model schema specified. Unsupported keyword(s): ["x-nullable"], Invalid model schema specified. Unsupported keyword(s): ["x-nullable"], Invalid model schema specified. Unsupported keyword(s): ["x-nullable"]] (Service: ApiGateway, Status Code: 400, Request ID: f914e6ad-0b0e-4b9c-9ed9-af325c29b520)" (RequestToken: 03e558fc-3e4d-6973-4bbf-52343e91d1b1, HandlerErrorCode: InvalidRequest)

# Provável problema

[Questão gatilho](https://stackoverflow.com/questions/48111459/how-to-define-a-property-that-can-be-string-or-null-in-openapi-swagger)

> OpenAPI 2.0
> 
> OAS2 does not support 'null' as the data type, so you are out of luck. You can only use type: string. However, some tools support x-nullable: true as a vendor extension, even though nulls are not part of the OpenAPI 2.0 Specification.
> 
> Consider migrating to OpenAPI v. 3 to get proper support for nulls.

Passar `"nullable": true` ao invés de `"x-nullable": true` seria suficiente!